### PR TITLE
Common mistakes

### DIFF
--- a/concepts/peers.md
+++ b/concepts/peers.md
@@ -36,9 +36,10 @@ type Tie <: Multiple[Client] with Single[Registry]
 ```
 
 ## Optional Connections
-If a tie might not be needed during the complete runtime of a program (e.g. if an introducer is used),
-it can be specified using an `Optional` tie:
+If a tie might not be needed during the complete runtime of a program (e.g. if an introducer is used), it can be specified using an `Optional` tie:
 ```scala
 type Tie <: Multiple[Client] with Optional[Registry]
 ```
-In this case the connection to the Registry might not be available, which has to be handled by the programmer.
+In this case the connection to the Registry might not be available. As such, accesses to the optional peer will yield `Option` values, which can be handled by the programmer.
+
+Note that `Optional` is used for managing a 1-to-1 relationship between peers. If there is a 1-to-n relationship in which n can be 0, the `Multiple` keyword should be used instead.

--- a/concepts/placement.md
+++ b/concepts/placement.md
@@ -43,6 +43,23 @@ val chats = on[Registry] { new Array[String](10)}
 val chats: Array[String] on Registry = placed { new Array[String](10)}
 ```
 
+## Subjective Values
+By default, every peer accessing a shared value will receive the same data. In some cases, it is beneficial to return a different value based on the accessing peer instance. In this case subjective values can be used.
+
+The `sbj` modifier binds an identifier holding a reference to the peer instance that accesses the subjective value. This identifier can be used to filter the returned value on a per remote peer basis.
+
+For example, in the following code snippet, a `Client` accessing `publicMessage` will receive all `message` values of other `Client` instances, but not his own.
+
+```scala
+val message = on[Client] { Evt[String] }
+
+val publicMessage = on[Server] sbj { client: Remote[Client] =>
+  message.asLocalFromAllSeq collect {
+    case (remote, message) if remote != client => message
+  }
+}
+```
+
 ## Local-Only Placement
 Variables and functions defined with `on` are visible and accessible by all peers. If only local access on the peer is needed, a `Local[*]` type can be used.
 ```scala

--- a/concepts/placement.md
+++ b/concepts/placement.md
@@ -36,18 +36,18 @@ Notice that while the first example uses an `on[*]` block to tell Loci about the
 The syntax for variables is quite similar to the one for functions:
 
 ```scala
-val chats = on[Registry] { new Array[Strings](10)}
+val chats = on[Registry] { new Array[String](10)}
 ```
 
 ```scala
-val chats: Array[Strings] on Registry = placed { new Array[Strings](10)}
+val chats: Array[String] on Registry = placed { new Array[String](10)}
 ```
 
 ## Local-Only Placement
 Variables and functions defined with `on` are visible and accessible by all peers. If only local access on the peer is needed,
 a `Local[*]` type can be used.
 ```scala
-val local_chats: Local[Array[Strings]] on Registry = placed { new Array[Strings](5)}
+val local_chats: Local[Array[String]] on Registry = placed { new Array[String](5)}
 ```
 <div class="code-example" markdown="1">
 

--- a/concepts/placement.md
+++ b/concepts/placement.md
@@ -44,10 +44,13 @@ val chats: Array[String] on Registry = placed { new Array[String](10)}
 ```
 
 ## Local-Only Placement
-Variables and functions defined with `on` are visible and accessible by all peers. If only local access on the peer is needed,
-a `Local[*]` type can be used.
+Variables and functions defined with `on` are visible and accessible by all peers. If only local access on the peer is needed, a `Local[*]` type can be used.
 ```scala
 val local_chats: Local[Array[String]] on Registry = placed { new Array[String](5)}
+```
+The `local` keyword can also be used instead, in which case Scala will infer the type automatically. It behaves similarly to `placed` expressions.
+```scala
+val local_chats = on[Registry] local { new Array[String](5)}
 ```
 <div class="code-example" markdown="1">
 

--- a/concepts/placement.md
+++ b/concepts/placement.md
@@ -44,11 +44,17 @@ val chats: Array[String] on Registry = placed { new Array[String](10)}
 ```
 
 ## Subjective Values
-By default, every peer accessing a shared value will receive the same data. In some cases, it is beneficial to return a different value based on the accessing peer instance. In this case subjective values can be used.
+By default, every peer accessing a shared value will receive the same data. In some cases, it is beneficial to return a 
+different value based on the accessing peer instance. In this case subjective values can be used.
 
-The `sbj` modifier binds an identifier holding a reference to the peer instance that accesses the subjective value. This identifier can be used to filter the returned value on a per remote peer basis.
+The `sbj` modifier binds an identifier holding a reference to the peer instance that accesses the subjective value. 
+This identifier can be used to operate (e.g. mapping) on a per remote peer basis. The values are created and saved
+on a per remote basis. Peers can then request the value (e.g. using `asLocal`) in order to transmit the value from
+the peer, that holds the specific value, to the request issuer. 
 
-For example, in the following code snippet, a `Client` accessing `publicMessage` will receive all `message` values of other `Client` instances, but not his own.
+For example, in the following code snippet, a `Client` accessing `publicMessage` will receive all `message` values of 
+other `Client` instances, but not his own. Internally there are multiple `publicMessage` values, one for each connected
+peer. Code inside the `sbj` runs locally (here: on the Server) and updates the internal values one by one.
 
 ```scala
 val message = on[Client] { Evt[String] }

--- a/concepts/remote_access.md
+++ b/concepts/remote_access.md
@@ -54,10 +54,10 @@ There are two variants of the `asLocal` function, which allow accessing the unde
 ## Variables
 Accessing variables works by using the `asLocal` directive as well:
 ```scala
-val counter = placed[Client] {0}
-val geigercounter = placed[Server] {0}
+val counter = on[Client] {0}
+val geigercounter = on[Server] {0}
 
-placed[Client].main {
+on[Client].main {
     print(counter) // 0, the initial local value
     print(counter.asLocalFromAll) // retrieve all connected counter values
 }
@@ -78,9 +78,9 @@ def main() = on[Client]{
 ```
 Accessing and returning values can be done by using `capture` and `asLocal`:
 ```scala
-var counter = placed[Server] {0}
-def increment(a: Int) = placed[Server] {counter += a; counter}
-placed[Client].main {
+var counter = on[Server] {0}
+def increment(a: Int) = on[Server] {counter += a; counter}
+on[Client].main {
     val i = 15
     val new_counter_value = remote[Server].capture(i) {
         increment(i)

--- a/concepts/remote_access.md
+++ b/concepts/remote_access.md
@@ -19,7 +19,7 @@ To access remote functions **with no return values**, they have to be called usi
 var counter = on[Client] {0}
 def increment() = on[Client] {counter += 1}
 
-def main() = (on[Client] {
+def main(): Unit on Peer = (on[Client] {
         increment() // executed locally
         remote call increment() // executed an all Client instances, except on this one
     }) and

--- a/concepts/serializing.md
+++ b/concepts/serializing.md
@@ -1,0 +1,60 @@
+---
+layout: default
+title: Transmittables
+parent: Concepts
+nav_order: 3
+---
+# Transmittables
+
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+## Primitives
+
+Scala-Loci implements serialization support for a set of common objects. This includes primitives like
+`String`, `Int` and often used collections like `Map`, `Option` and `Array`.
+
+## Custom transmittables
+
+However, if you require custom transmittable objects, you need to use custom serializer. In the following example,
+we will use `upickle`[https://github.com/lihaoyi/upickle] for this. 
+
+Here we want to transport this case class between peers. For simple objects we could use `IdenticallyTransmittable`,
+this will serialize it as-is.
+```scala
+// import serializer lib
+import upickle.default._
+
+// the object we want to transport
+final case class Failure(reason: String)
+
+package object command {
+  // mark it as transmittable without any custom logic
+  implicit val resultTransmittable: IdenticallyTransmittable[Failure] = IdenticallyTransmittable()
+  // create a upickle readwriter that should be used - here we can use the default one
+  implicit val rwResult: ReadWriter[CommandResult] = macroRW
+}
+```
+
+### Companion Objects
+
+As an alternative to the above approach we could also use companion objects.  
+
+```scala
+object Failure {
+  final implicit def transmittableResult: IdenticallyTransmittable[Failure] = IdenticallyTransmittable()
+  implicit val rwResult: ReadWriter[Failure] = macroRW
+}
+```
+
+## Common Issues
+
+### NPE
+
+If you use `implicit`s and inheritance for the transmittable objects, the order of the definitions is relevant for 
+Scala. `ReadWriter`s should be defined from child to parent, or you will encounter a runtime exception. 

--- a/faq.md
+++ b/faq.md
@@ -69,7 +69,7 @@ Another peer can no longer access this value.
 
 Considering a control interface with a switch. We want to know which peer last changed this value. Therefore,
 we use a tuple containing the current value and peer instance (here: an administrator) who requested the change. In this 
-example we use optional for representing a non-peer change (e.g. physical access) or for its initial value.
+example we use option for representing a non-peer change (e.g. physical access) or for its initial value.
 ```scala
 val setting: Local[Signal[(Option[Remote[AdminClient]], Boolean)]] on Server = placed { ... }
 ```

--- a/faq.md
+++ b/faq.md
@@ -41,6 +41,17 @@ keyword between two peers. If you have more than two peers, you need to add corr
 the implementation of peer `Client` is combined with the tuple of `(Controller and Server)`.
 
 ```scala
+  @peer type Peer
+
+  // behind peer you could include more sub peers using with ...
+  @peer type Server <: Peer {
+    type Tie <: [...]
+  }
+
+  @peer type Client <: Peer {
+    type Tie <: [...]
+  }
+
   def main(): Unit on Peer = on[Client] {
     // main method on Client
   } and (on[Controller] {

--- a/faq.md
+++ b/faq.md
@@ -14,6 +14,25 @@ Here you can find a few common questions regarding the framework.
 1. TOC
 {:toc}
 
+## Blocking method calls and endless loops
+
+If you perform any blocking calls (i.e. `Thread.sleep`, endless loops or `I/O`), you should move them to your main 
+method. Otherwise it could block the communication and initialization of the multitier object.
+
+```scala
+  // Avoid:
+  on[Server] {
+    while (running) {
+        ...
+    }
+  }
+
+  // Better:
+  def main() = on[Server] {
+    // perform it here   
+  }
+```
+
 ## Defining main method in multiple peers
 
 If your application requires a method with the same name, but with different semantics on different peers, you have

--- a/faq.md
+++ b/faq.md
@@ -14,6 +14,23 @@ Here you can find a few common questions regarding the framework.
 1. TOC
 {:toc}
 
+## Defining main method in multiple peers
+
+If your application requires a method with the same name, but with different semantics on different peers, you have
+to define a common peer type and specify the return type explicitly. You can then combine the logic using the `and`
+keyword between two peers. If you have more than two peers, you need to add correct parenthesis like below. So
+the implementation of peer `Client` is combined with the tuple of `(Controller and Server)`.
+
+```scala
+  def main(): Unit on Peer = on[Client] {
+    // main method on Client
+  } and (on[Controller] {
+    // main method of controller
+  } and on[Server] {
+    // main method of server
+  })
+```
+
 ## Remote[*] is not transmittable
 
 `Remotes[*]` are used to indentify locally connected peers. They have no global meaning

--- a/faq.md
+++ b/faq.md
@@ -193,3 +193,5 @@ You can try replacing `event.fold(init) { ... }` with `Events.foldOne(event, ini
 ## Where are my exceptions?
 
 Per default, exceptions are not printed in Loci. So if your application just stops working, be sure to handle all possible exceptions yourself. For example, `.asLocal_?` might throw an exception if the Await times out. Therefore, it can help to wrap it in a `Try {}`.
+
+In Scala-Loci 0.4.0 this behavior changed. Exception will be printed now by default.

--- a/faq.md
+++ b/faq.md
@@ -53,14 +53,17 @@ the implementation of peer `Client` is combined with the tuple of `(Controller a
 ## Remote[*] is not transmittable
 
 `Remotes[*]` are used to identify locally connected peers. They have no global meaning
-and are therefore not transmittable. If you still want to save the peer you could make value definitions local like so:
+and are therefore not transmittable. If you need to save an instance of a remote, you could define the value as local.
+Another peer can no longer access this value.
 
+Considering a control interface with a switch. We want to know which peer last changed this value. Therefore,
+we use a tuple containing the current value and peer instance who requested the change. In this example we
+use optional for representing a non-peer change (e.g. physical access) or for its initial value.
 ```scala
-// remote represent the account who changed the setting
 val setting: Local[Signal[(Option[Remote[AdminClient]], Boolean)]] on Server = placed { ... }
 ```
 
-If you need to transfer those values you could create a new signal containing only the transmittable
+If you need to transfer those values, you could create a new signal containing only the transmittable
 content (ex: the second value of the tuple from above), you could map the `Remote[*]` to a unique or otherwise
 representable value:
 

--- a/faq.md
+++ b/faq.md
@@ -94,7 +94,7 @@ representable value:
 
 ## Mismatched types Future
 
-In combination with serializing the data in could happen that you get errors about
+In combination with serializing the data for `ReScala` in could happen that you get errors about
 mismatched types when transferring the data over different peers. This could be caused if you forgot
 to include the required import statement.
 

--- a/faq.md
+++ b/faq.md
@@ -68,7 +68,7 @@ representable value:
   val whoChangedSetting = on[Server] sbj {
     requestor: Remote[AdminClient] => {
       setting.changed.map {
-        case (remote, value) if remote == requestor => "User: " + (username from remote).asLocal + " changed settins to " + value
+        case (remote, value) if remote == requestor => "User: " + (username from remote).asLocal + " changed settings to " + value
         case (remote, value) if remote != requestor => "Succces: You changed the settings to " + value
       }.latest()
     }

--- a/faq.md
+++ b/faq.md
@@ -75,6 +75,16 @@ representable value:
   }
 ``` 
 
+## Mismatched types Future
+
+In combination with serializing the data in could happen that you get errors about
+mismatched types when transferring the data over different peers. This could be caused if you forgot
+to include the required import statement.
+
+```scala
+// This import is necessary to fix type mismatch with Future
+import loci.transmitter.rescala._
+```
 
 ## My peers mysteriously stop working without any error message
 

--- a/faq.md
+++ b/faq.md
@@ -14,6 +14,32 @@ Here you can find a few common questions regarding the framework.
 1. TOC
 {:toc}
 
+## Remote[*] is not transmittable
+
+`Remotes[*]` are used to indentify locally connected peers. They have no global meaning
+and are therefore not transmittable. If you still want to save the peer you could make value definitions local like so:
+
+```scala
+// remote represent the account who changed the setting
+val setting: Local[Signal[(Option[Remote[AdminClient]], Boolean)]] on Server = placed { ... }
+```
+
+If you need to transfer those values you could create a new signal containing only the transmittable
+content (ex: the second value of the tuple from above) or you could map the `Remote[*]` to a unique or otherwise
+representable value:
+
+```scala
+  val whoChangedSetting = on[Server] sbj {
+    requestor: Remote[AdminClient] => {
+      setting.changed.map {
+        case (remote, value) if remote == requestor => "User: " + (username from remote).asLocal + " changed settins to " + value
+        case (remote, value) if remote != requestor => "Succces: You changed the settings to " + value
+      }.latest()
+    }
+  }
+``` 
+
+
 ## My peers mysteriously stop working without any error message
 
 This might be caused by an uncaught exception. If an exceptions occurs and is not properly handled, a node can crash without any warnings. To find the cause of the exception, you can try observing the reactives:

--- a/faq.md
+++ b/faq.md
@@ -199,10 +199,12 @@ You can try replacing `event.fold(init) { ... }` with `Events.foldOne(event, ini
 ## My right events combined with '||' are not firing
 
 The ReScala notation with `||` is used for or. The operator is left-biased. This means
-if the event on the left side is already firing, you right events that fire at the same time
+if the event on the left side is already firing, your right events that fire at the same time
 are ignored. You can use `Events.foldAll` if you need to save the result. However, if
 you only need an event and not a signal, you would have to manually reset it. An alternative
-is to combine them with `Event.zipOuter`. Here is example combining sequence of events.
+is to combine them with `Event.zipOuter`. The following example builds a single event that zips a sequence
+of events each containing a single string to a sequence of strings. This could be useful if you have multiple
+sources that output a single log messages and you need an event where you listen to in order to print the output.
 
 ```scala
 val events: Seq[Event[String]] = [...]

--- a/faq.md
+++ b/faq.md
@@ -196,12 +196,6 @@ The trick is to map `someEvent` into a pair with the current value of `sig`. Aft
 
 You can try replacing `event.fold(init) { ... }` with `Events.foldOne(event, init) { ... }`
 
-## Where are my exceptions?
-
-Per default, exceptions are not printed in Loci. So if your application just stops working, be sure to handle all possible exceptions yourself. For example, `.asLocal_?` might throw an exception if the Await times out. Therefore, it can help to wrap it in a `Try {}`.
-
-In Scala-Loci 0.4.0 this behavior changed. Exception will be printed now by default.
-
 ## My right events combined with '||' are not firing
 
 The ReScala notation with `||` is used for or. The operator is left-biased. This means

--- a/faq.md
+++ b/faq.md
@@ -64,7 +64,7 @@ the implementation of peer `Client` is combined with the tuple of `(Controller a
 ## Remote[*] is not transmittable
 
 `Remotes[*]` are used to identify locally connected peers. They have no global meaning
-and are therefore not transmittable. If you need to save an instance of a remote, you could define the value as local.
+and are therefore not transmittable. If you need to save an instance of a remote, you need define the value as local.
 Another peer can no longer access this value.
 
 Considering a control interface with a switch. We want to know which peer last changed this value. Therefore,

--- a/faq.md
+++ b/faq.md
@@ -17,7 +17,7 @@ Here you can find a few common questions regarding the framework.
 ## Blocking method calls and endless loops
 
 If you perform any blocking calls (i.e. `Thread.sleep`, endless loops or `I/O`), you should move them to your main 
-method. Otherwise it could block the communication and initialization of the multitier object.
+method. Otherwise, it could block the communication and initialization of the multitier object.
 
 ```scala
   // Avoid:
@@ -52,7 +52,7 @@ the implementation of peer `Client` is combined with the tuple of `(Controller a
 
 ## Remote[*] is not transmittable
 
-`Remotes[*]` are used to indentify locally connected peers. They have no global meaning
+`Remotes[*]` are used to identify locally connected peers. They have no global meaning
 and are therefore not transmittable. If you still want to save the peer you could make value definitions local like so:
 
 ```scala
@@ -61,15 +61,15 @@ val setting: Local[Signal[(Option[Remote[AdminClient]], Boolean)]] on Server = p
 ```
 
 If you need to transfer those values you could create a new signal containing only the transmittable
-content (ex: the second value of the tuple from above) or you could map the `Remote[*]` to a unique or otherwise
+content (ex: the second value of the tuple from above), you could map the `Remote[*]` to a unique or otherwise
 representable value:
 
 ```scala
   val whoChangedSetting = on[Server] sbj {
-    requestor: Remote[AdminClient] => {
+    requestSource: Remote[AdminClient] => {
       setting.changed.map {
-        case (remote, value) if remote == requestor => "User: " + (username from remote).asLocal + " changed settings to " + value
-        case (remote, value) if remote != requestor => "Succces: You changed the settings to " + value
+        case (remote, value) if remote == requestSource => "User: " + (username from requestSource).asLocal + " changed settings to " + value
+        case (remote, value) if remote != requestSource => "Success: You changed the settings to " + value
       }.latest()
     }
   }

--- a/faq.md
+++ b/faq.md
@@ -57,8 +57,8 @@ and are therefore not transmittable. If you need to save an instance of a remote
 Another peer can no longer access this value.
 
 Considering a control interface with a switch. We want to know which peer last changed this value. Therefore,
-we use a tuple containing the current value and peer instance who requested the change. In this example we
-use optional for representing a non-peer change (e.g. physical access) or for its initial value.
+we use a tuple containing the current value and peer instance (here: an administrator) who requested the change. In this 
+example we use optional for representing a non-peer change (e.g. physical access) or for its initial value.
 ```scala
 val setting: Local[Signal[(Option[Remote[AdminClient]], Boolean)]] on Server = placed { ... }
 ```
@@ -70,9 +70,12 @@ representable value:
 ```scala
   val whoChangedSetting = on[Server] sbj {
     requestSource: Remote[AdminClient] => {
+      // update on change
       setting.changed.map {
-        case (remote, value) if remote == requestSource => "User: " + (username from requestSource).asLocal + " changed settings to " + value
-        case (remote, value) if remote != requestSource => "Success: You changed the settings to " + value
+        // Someone else changed the value
+        case (Some(remote), value) if remote != requestSource => "User: " + (username from requestSource).asLocal + " changed settings to " + value
+        // we changed it
+        case (Some(remote), value) if remote == requestSource => "Success: You changed the settings to " + value
       }.latest()
     }
   }

--- a/getting_started/execution.md
+++ b/getting_started/execution.md
@@ -39,6 +39,8 @@ Notice how the **Server** instance uses `listen[Chat.Client]` to open a port for
 If you got everything right, the complete chat application should look like this now:
 
 ```scala
+package chatsimple
+
 import loci._
 import loci.transmitter.rescala._
 import loci.serializer.upickle._

--- a/getting_started/multitier_setup.md
+++ b/getting_started/multitier_setup.md
@@ -40,8 +40,7 @@ import rescala.default._
 In a ScalaLoci application, all code has to live in the multitier environment which you specify with the `@multitier` annotation.
 
 ```scala
-@multitier
-object Chat {
+@multitier object Chat {
     // server and client code lives in here
 }
 ```

--- a/getting_started/placement.md
+++ b/getting_started/placement.md
@@ -42,7 +42,7 @@ val publicMessage = on[Server] sbj { client: Remote[Client] =>
 }
 ```
 
-Notice the `sbj` keyword which let's us adapt the value to each peer that is accessing it. In this example we use this to not display their own messages to clients that are accessing the public messages.
+Notice the `sbj` keyword which lets us adapt the value to each peer that is accessing it. In this example we use this to not display their own messages to clients that are accessing the public messages.
 
 ## Placing Functions
 

--- a/getting_started/placement.md
+++ b/getting_started/placement.md
@@ -54,8 +54,9 @@ def main() = on[Client] {
     publicMessage.asLocal observe println
 
     // let the user send new messages via stdin
-    for (line <- scala.io.Source.stdin.getLines)
+    for (line <- scala.io.Source.stdin.getLines) {
       message.fire(line)
+    }
     }
 }
 ```

--- a/getting_started/placement.md
+++ b/getting_started/placement.md
@@ -57,8 +57,6 @@ def main() = on[Client] {
     for (line <- scala.io.Source.stdin.getLines) {
       message.fire(line)
     }
-    }
-}
 ```
 
 Notice how we access the `publicMessage` event which is stored on another peer (the server) using `asLocal`.


### PR DESCRIPTION
During the project we used the papers and including this project for getting started with the framework. We encountered some issues on our own and thought it makes the sense to improve it based on our experience. 

Some parts of the papers were outdated and some minor things in this project too. Here is a summary of the changes we did:

Summary
- Added:
    - [X] Advise against blocking calls in fields
    - [X] How to define a common `main` method
    - [X] Add section explaining about subjective values
    - [X] Explain not transmittable `Remote[*]`
    - [X] Alternative `local` syntax
    - [x] Explain type mismatch error with `Future`s for missing imports
    - [x] Transmittable `upickle` example (package declaration vs our companion objects)
- [X] Clarify `Optional` peer definitions usage

- Fixes:
   - [X] Fix some typos
   - [X] Fix ability to run the examples like adding missing `package` declaration
   - [X] Drop outdated placed[*] syntax
  
Updated:
- Fixes:
   - [X] Updated exception printing